### PR TITLE
fix: prevent double "v" prefix in version badge

### DIFF
--- a/web/app/components/VersionBadge/VersionBadge.tsx
+++ b/web/app/components/VersionBadge/VersionBadge.tsx
@@ -1,5 +1,5 @@
 const version = process.env.NEXT_PUBLIC_VERSION;
-const label = version ? `v${version}` : "dev";
+const label = version ?? "dev";
 
 export default function VersionBadge() {
 	return (


### PR DESCRIPTION
NEXT_PUBLIC_VERSION already includes the "v" prefix (e.g. "v0.5.0"), so the component should use it as-is instead of prepending another "v".