### PR TITLE
fix: decouple tests from real scripts/ directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Run E2E tests
-        run: bunx turbo run test:e2e
+        run: SCRIPTS_DIR=scripts-fixture bunx turbo run test:e2e

--- a/20_Applications/scriptor-web-test/tests/browse.spec.ts
+++ b/20_Applications/scriptor-web-test/tests/browse.spec.ts
@@ -5,24 +5,24 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("browse page loads and shows windows scripts", async ({ page }) => {
-	await expect(page.getByText("Setup winget")).toBeVisible();
-	await expect(page.getByText("Install Git")).toBeVisible();
-	await expect(page.getByText("Install VS Code")).toBeVisible();
+	await expect(page.getByText("Fixture Setup Package Manager")).toBeVisible();
+	await expect(page.getByText("Fixture Install Git")).toBeVisible();
+	await expect(page.getByText("Fixture Install Editor")).toBeVisible();
 });
 
 test("each script row shows its description", async ({ page }) => {
 	await expect(
-		page.getByText("Ensures the Windows Package Manager (winget) is up to date."),
+		page.getByText("A fixture script for setting up the package manager."),
 	).toBeVisible();
 });
 
 test("clicking a script row navigates to the detail page", async ({ page }) => {
-	await page.getByText("Setup winget").click();
+	await page.getByText("Fixture Setup Package Manager").click();
 
 	await expect(page).toHaveURL(
-		/\/scripts\/windows\/windows-11-x64\/setup-winget/,
+		/\/scripts\/windows\/windows-11-x64\/fixture-setup-pkgmgr/,
 	);
 	await expect(
-		page.getByRole("heading", { name: /Setup winget/ }),
+		page.getByRole("heading", { name: /Fixture Setup Package Manager/ }),
 	).toBeVisible();
 });

--- a/20_Applications/scriptor-web-test/tests/detail.spec.ts
+++ b/20_Applications/scriptor-web-test/tests/detail.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-	await page.goto("/scripts/linux/ubuntu-24.04-x64/install-curl");
+	await page.goto("/scripts/linux/ubuntu-24.04-x64/fixture-install-curl");
 });
 
 test("detail page shows the script title", async ({ page }) => {
 	await expect(
-		page.getByRole("heading", { name: "Install curl" }),
+		page.getByRole("heading", { name: "Fixture Install curl" }),
 	).toBeVisible();
 });
 
@@ -20,7 +20,7 @@ test("detail page shows single target tag via formatTarget", async ({
 test("detail page shows the run command text", async ({ page }) => {
 	await expect(
 		page.getByText(
-			"curl -fsSL https://raw.githubusercontent.com/beolson/Scriptor/main/scripts/linux/ubuntu-24.04-x64/install-curl.sh | bash",
+			"curl -fsSL https://raw.githubusercontent.com/beolson/Scriptor/main/scripts/linux/ubuntu-24.04-x64/fixture-install-curl.sh | bash",
 		),
 	).toBeVisible();
 });
@@ -30,9 +30,9 @@ test("copy button is visible on the detail page", async ({ page }) => {
 });
 
 test("mac detail page shows correct title and target tag", async ({ page }) => {
-	await page.goto("/scripts/mac/macos-sequoia-arm64/install-homebrew");
+	await page.goto("/scripts/mac/macos-sequoia-arm64/fixture-install-brew");
 	await expect(
-		page.getByRole("heading", { name: "Install Homebrew" }),
+		page.getByRole("heading", { name: "Fixture Install Brew" }),
 	).toBeVisible();
 	// formatTarget("macos-sequoia-arm64") => "Macos Sequoia Arm64"
 	await expect(page.getByText("Macos Sequoia Arm64").first()).toBeVisible();
@@ -41,9 +41,9 @@ test("mac detail page shows correct title and target tag", async ({ page }) => {
 test("windows detail page shows correct title and target tag", async ({
 	page,
 }) => {
-	await page.goto("/scripts/windows/windows-11-x64/setup-winget");
+	await page.goto("/scripts/windows/windows-11-x64/fixture-setup-pkgmgr");
 	await expect(
-		page.getByRole("heading", { name: "Setup winget" }),
+		page.getByRole("heading", { name: "Fixture Setup Package Manager" }),
 	).toBeVisible();
 	// formatTarget("windows-11-x64") => "Windows 11 X64"
 	await expect(page.getByText("Windows 11 X64").first()).toBeVisible();

--- a/20_Applications/scriptor-web-test/tests/smoke.spec.ts
+++ b/20_Applications/scriptor-web-test/tests/smoke.spec.ts
@@ -18,7 +18,10 @@ test("clicking a platform card navigates to that platform's script list", async 
 	page,
 }) => {
 	await page.goto("/");
-	await page.getByRole("link", { name: /windows/i }).first().click();
+	await page
+		.getByRole("link", { name: /windows/i })
+		.first()
+		.click();
 	await expect(page).toHaveURL(/\/scripts\/windows/);
-	await expect(page.getByText("Setup winget")).toBeVisible();
+	await expect(page.getByText("Fixture Setup Package Manager")).toBeVisible();
 });

--- a/20_Applications/scriptor-web/lib/loadScripts.test.ts
+++ b/20_Applications/scriptor-web/lib/loadScripts.test.ts
@@ -1,7 +1,16 @@
 // @vitest-environment node
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import type { LoadScriptsDeps } from "./loadScripts.js";
-import { loadScripts } from "./loadScripts.js";
+import { defaultDeps, loadScripts } from "./loadScripts.js";
+
+// Navigate from lib/ → scriptor-web/ → 20_Applications/ → repo root → scripts-fixture/
+const fixtureDir = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../../..",
+	"scripts-fixture",
+);
 
 // Helper to build a minimal spec file string using new single-field platform
 function makeSpec(overrides: Record<string, string> = {}): string {
@@ -260,16 +269,16 @@ describe("loadScripts()", () => {
 	});
 });
 
-// ─── Integration tests against real scripts/ folder ──────────────────────────
+// ─── Integration tests against scripts-fixture/ ──────────────────────────────
 
-describe("loadScripts() integration — real scripts/ folder", () => {
+describe("loadScripts() integration — scripts-fixture/ folder", () => {
 	it("loads at least 3 scripts total", async () => {
-		const scripts = await loadScripts();
+		const scripts = await loadScripts(defaultDeps(fixtureDir));
 		expect(scripts.length).toBeGreaterThanOrEqual(3);
 	});
 
 	it("every loaded script has a non-empty title and id", async () => {
-		const scripts = await loadScripts();
+		const scripts = await loadScripts(defaultDeps(fixtureDir));
 		for (const s of scripts) {
 			expect(s.title.length).toBeGreaterThan(0);
 			expect(s.id.length).toBeGreaterThan(0);
@@ -277,7 +286,7 @@ describe("loadScripts() integration — real scripts/ folder", () => {
 	});
 
 	it("every loaded script has a platform string (combined target)", async () => {
-		const scripts = await loadScripts();
+		const scripts = await loadScripts(defaultDeps(fixtureDir));
 		for (const s of scripts) {
 			expect(typeof s.platform).toBe("string");
 			expect(s.platform.length).toBeGreaterThan(0);

--- a/20_Applications/scriptor-web/lib/loadScripts.ts
+++ b/20_Applications/scriptor-web/lib/loadScripts.ts
@@ -115,13 +115,17 @@ export const defaultDeps = (scriptsDir: string): LoadScriptsDeps => ({
  * When called without `deps`, uses Bun-native APIs against the real
  * `scripts/` folder at the repo root (3 levels above this module).
  */
+// Navigate from lib/ → scriptor-web/ → 20_Applications/ → repo root
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+// Allow SCRIPTS_DIR env var to override the default scripts/ folder (e.g. for testing)
+// process.env is used (not Bun.env) because this module also runs under Vitest/Node.
+const defaultScriptsDir = process.env.SCRIPTS_DIR
+	? resolve(repoRoot, process.env.SCRIPTS_DIR)
+	: resolve(repoRoot, "scripts");
+
 export async function loadScripts(deps?: LoadScriptsDeps): Promise<Script[]> {
-	const resolvedDeps =
-		deps ??
-		defaultDeps(
-			// Navigate from lib/ → scriptor-web/ → 20_Applications/ → repo root → scripts/
-			resolve(dirname(fileURLToPath(import.meta.url)), "../../..", "scripts"),
-		);
+	const resolvedDeps = deps ?? defaultDeps(defaultScriptsDir);
 
 	const { glob, readFile, scriptsDir } = resolvedDeps;
 

--- a/20_Applications/scriptor-web/next-env.d.ts
+++ b/20_Applications/scriptor-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"format": "biome format --write .",
 		"typecheck": "turbo run typecheck",
 		"test:unit": "turbo run test:unit",
-		"test:e2e": "turbo run test:e2e",
+		"test:e2e": "SCRIPTS_DIR=scripts-fixture turbo run test:e2e",
 		"db:dev": "docker compose -f 40_Infrastructure/docker-compose.dev.yml up -d",
 		"shadcn": "bun --cwd 20_Applications/agent-sap shadcn",
 		"db:migrate": "bun --cwd 20_Applications/agent-sap run db:migrate",

--- a/scripts-fixture/linux/ubuntu-24.04-x64/fixture-install-curl.md
+++ b/scripts-fixture/linux/ubuntu-24.04-x64/fixture-install-curl.md
@@ -1,0 +1,7 @@
+---
+platform: ubuntu-24.04-x64
+title: Fixture Install curl
+description: A fixture script for testing curl installation.
+---
+
+Fixture script — installs curl for test purposes.

--- a/scripts-fixture/linux/ubuntu-24.04-x64/fixture-install-curl.sh
+++ b/scripts-fixture/linux/ubuntu-24.04-x64/fixture-install-curl.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "fixture: install curl"

--- a/scripts-fixture/linux/ubuntu-24.04-x64/fixture-setup-dev.md
+++ b/scripts-fixture/linux/ubuntu-24.04-x64/fixture-setup-dev.md
@@ -1,0 +1,7 @@
+---
+platform: ubuntu-24.04-x64
+title: Fixture Setup Dev
+description: A fixture script for setting up a dev environment.
+---
+
+Fixture script — sets up a dev environment for test purposes.

--- a/scripts-fixture/linux/ubuntu-24.04-x64/fixture-setup-dev.sh
+++ b/scripts-fixture/linux/ubuntu-24.04-x64/fixture-setup-dev.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "fixture: setup dev"

--- a/scripts-fixture/mac/macos-sequoia-arm64/fixture-install-brew.md
+++ b/scripts-fixture/mac/macos-sequoia-arm64/fixture-install-brew.md
@@ -1,0 +1,7 @@
+---
+platform: macos-sequoia-arm64
+title: Fixture Install Brew
+description: A fixture script for testing Homebrew installation.
+---
+
+Fixture script — installs Homebrew for test purposes.

--- a/scripts-fixture/mac/macos-sequoia-arm64/fixture-install-brew.sh
+++ b/scripts-fixture/mac/macos-sequoia-arm64/fixture-install-brew.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "fixture: install brew"

--- a/scripts-fixture/windows/windows-11-x64/fixture-install-editor.md
+++ b/scripts-fixture/windows/windows-11-x64/fixture-install-editor.md
@@ -1,0 +1,7 @@
+---
+platform: windows-11-x64
+title: Fixture Install Editor
+description: A fixture script for testing editor installation.
+---
+
+Fixture script — installs an editor for test purposes.

--- a/scripts-fixture/windows/windows-11-x64/fixture-install-editor.ps1
+++ b/scripts-fixture/windows/windows-11-x64/fixture-install-editor.ps1
@@ -1,0 +1,1 @@
+Write-Output "fixture: install editor"

--- a/scripts-fixture/windows/windows-11-x64/fixture-install-git.md
+++ b/scripts-fixture/windows/windows-11-x64/fixture-install-git.md
@@ -1,0 +1,7 @@
+---
+platform: windows-11-x64
+title: Fixture Install Git
+description: A fixture script for testing Git installation.
+---
+
+Fixture script — installs Git for test purposes.

--- a/scripts-fixture/windows/windows-11-x64/fixture-install-git.ps1
+++ b/scripts-fixture/windows/windows-11-x64/fixture-install-git.ps1
@@ -1,0 +1,1 @@
+Write-Output "fixture: install git"

--- a/scripts-fixture/windows/windows-11-x64/fixture-setup-pkgmgr.md
+++ b/scripts-fixture/windows/windows-11-x64/fixture-setup-pkgmgr.md
@@ -1,0 +1,7 @@
+---
+platform: windows-11-x64
+title: Fixture Setup Package Manager
+description: A fixture script for setting up the package manager.
+---
+
+Fixture script — sets up the package manager for test purposes.

--- a/scripts-fixture/windows/windows-11-x64/fixture-setup-pkgmgr.ps1
+++ b/scripts-fixture/windows/windows-11-x64/fixture-setup-pkgmgr.ps1
@@ -1,0 +1,1 @@
+Write-Output "fixture: setup package manager"

--- a/turbo.json
+++ b/turbo.json
@@ -5,9 +5,11 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
+			"env": ["SCRIPTS_DIR"],
 			"inputs": [
 				"$TURBO_DEFAULT$",
 				"../../scripts/**",
+				"../../scripts-fixture/**",
 				"!README.md",
 				"!**/*.test.ts",
 				"!**/*.spec.ts"


### PR DESCRIPTION
## Summary

- Adds `scripts-fixture/` at the repo root with 6 stable fixture scripts (2 Linux, 1 Mac, 3 Windows) that tests always rely on
- Adds `SCRIPTS_DIR` env var support to `loadScripts.ts` so the scripts directory can be overridden at build time
- Unit integration tests now point at `scripts-fixture/` instead of the real `scripts/` folder
- `bun run test:e2e` builds against `scripts-fixture/` via `SCRIPTS_DIR=scripts-fixture turbo run test:e2e`
- E2E test assertions updated to match fixture content
- `turbo.json` updated to include `SCRIPTS_DIR` in the build `env` list (separate cache entries per scripts dir)

Real scripts can now be freely replaced without touching any test file.

## Test plan

- [x] `bun run test:unit` — all 56 unit tests pass (integration tests now hit fixture dir)
- [x] `bun run test:e2e --force` — all 11 E2E tests pass against fixture build
- [ ] Verify `bun run build` (no `SCRIPTS_DIR`) still builds against real `scripts/`

> **Note for local dev:** If `bun run dev` is running on port 3000, stop it before running `bun run test:e2e` — Playwright will otherwise reuse the dev server (which uses real scripts). CI handles this automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)