### PR TITLE
chore: gitignore fixes and Debian 13 release changeset

### DIFF
--- a/.changeset/debian-13-platform.md
+++ b/.changeset/debian-13-platform.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": minor
+---
+
+Add Debian 13 (Trixie) x64 platform with 14 setup scripts covering GPU drivers, container runtimes (Docker/Podman/minikube), dev tools (Go, Bun, uv, .NET, Azure CLI, GitHub CLI), SSH hardening, and system configuration.

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,6 @@ Thumbs.db
 # Playwright test results
 test-results/
 
-# Claude Code worktrees
+# Claude Code worktrees and session files
 .claude/worktrees/
+.claude/*.lock

--- a/20_Applications/scriptor-web-test/test-results/.last-run.json
+++ b/20_Applications/scriptor-web-test/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Summary

- Untracks `test-results/.last-run.json` (now covered by the `test-results/` gitignore entry added in #38)
- Adds `.claude/*.lock` to gitignore to suppress Claude Code session lock files
- Adds a **minor** changeset for `@scriptor/scriptor-web` to trigger the release of the Debian 13 platform

## What this releases

Merging this PR → Changesets bot opens a version PR → merging that deploys the site with the Debian 13 x64 platform and all 14 new scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)