### PR TITLE
feat: add Windows 11 WSL and dev app install scripts

### DIFF
--- a/.changeset/windows-install-scripts.md
+++ b/.changeset/windows-install-scripts.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Add Windows 11 scripts: WSL Debian 13 setup and dev app installer (Windows Terminal, VS Code, Chrome)

--- a/scripts/windows/windows-11-x64/install-dev-apps.ps1
+++ b/scripts/windows/windows-11-x64/install-dev-apps.ps1
@@ -1,0 +1,58 @@
+<#
+---
+platform: windows-11-x64
+title: Install Dev Apps
+description: Installs Windows Terminal, VS Code, and Google Chrome via winget.
+---
+Installs a standard set of developer applications using the Windows Package Manager
+(`winget`). Each package is checked first — already-installed apps are skipped so
+the script is safe to run more than once.
+
+## What it does
+
+1. Verifies `winget` is available.
+2. Installs **Windows Terminal** — the modern tabbed terminal for PowerShell, CMD, and WSL.
+3. Installs **Visual Studio Code** — lightweight code editor.
+4. Installs **Google Chrome** — web browser.
+
+## Requirements
+
+- Windows 11
+- winget (App Installer) — pre-installed on Windows 11; update via the Microsoft Store if needed.
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Install-WingetPackage {
+    param(
+        [string]$Id,
+        [string]$Name
+    )
+
+    $installed = winget list --id $Id --exact 2>$null
+    if ($installed -match [regex]::Escape($Id)) {
+        Write-Host "$Name is already installed, skipping."
+        return
+    }
+
+    Write-Host "Installing $Name..."
+    winget install --id $Id --exact --silent --accept-source-agreements --accept-package-agreements
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install $Name."
+        exit 1
+    }
+    Write-Host "$Name installed." -ForegroundColor Green
+}
+
+# Verify winget is present
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Error "winget (App Installer) is required but was not found. Install it from the Microsoft Store."
+    exit 1
+}
+
+Install-WingetPackage -Id 'Microsoft.WindowsTerminal' -Name 'Windows Terminal'
+Install-WingetPackage -Id 'Microsoft.VisualStudioCode' -Name 'Visual Studio Code'
+Install-WingetPackage -Id 'Google.Chrome'              -Name 'Google Chrome'
+
+Write-Host "All apps installed." -ForegroundColor Green

--- a/scripts/windows/windows-11-x64/setup-wsl-debian13.ps1
+++ b/scripts/windows/windows-11-x64/setup-wsl-debian13.ps1
@@ -1,0 +1,101 @@
+<#
+---
+platform: windows-11-x64
+title: Setup WSL Debian 13
+description: Installs a named Debian 13 WSL instance and creates a local user account.
+---
+Installs a WSL 2 Debian 13 instance, creates a user account matching your Windows
+username, adds it to the `sudo` group, and sets it as the default login user.
+
+The instance name defaults to `Debian13Dev` but can be overridden by passing a name
+as the first argument: `.\setup-wsl-debian13.ps1 MyInstance`.
+
+## What it does
+
+1. Verifies `wsl.exe` is present on the system.
+2. Checks that the target instance name does not already exist.
+3. Installs Debian from the Microsoft Store via `wsl --install` without launching
+   the interactive first-run setup.
+4. Creates a user account inside the distro matching the current Windows username.
+5. Adds the user to the `sudo` group.
+6. Writes `/etc/wsl.conf` to set the new user as the default login.
+7. Terminates the instance so the configuration takes effect on next launch.
+
+## Requirements
+
+- Windows 11 with WSL 2 support enabled.
+- `wsl.exe` installed. If not present, run: `wsl --install --no-distribution`
+- Must be run as Administrator.
+#>
+
+#Requires -RunAsAdministrator
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$InstanceName = if ($args[0]) { $args[0] } else { 'Debian13Dev' }
+$WinUser = $env:USERNAME
+$Tag = '[setup-wsl-debian13]'
+
+Write-Host "$Tag Starting..."
+Write-Host "$Tag Instance name: $InstanceName"
+Write-Host "$Tag Windows user:  $WinUser"
+
+# Verify WSL is installed
+if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+    Write-Error "$Tag wsl.exe not found. Install WSL first:`n  wsl --install --no-distribution"
+    exit 1
+}
+
+# Check the instance does not already exist
+# wsl --list --quiet outputs UTF-16LE; normalize before comparing
+$ExistingInstances = (wsl --list --quiet 2>$null) |
+    ForEach-Object { $_.Trim("`0").Trim() } |
+    Where-Object { $_ -ne '' }
+
+if ($ExistingInstances -contains $InstanceName) {
+    Write-Error "$Tag WSL instance '$InstanceName' already exists. Remove it first:`n  wsl --unregister $InstanceName"
+    exit 1
+}
+
+# Install Debian without triggering the interactive first-run wizard
+Write-Host "$Tag Installing Debian WSL instance '$InstanceName'..."
+wsl --install -d Debian --name $InstanceName --no-launch
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "$Tag Failed to install WSL instance."
+    exit 1
+}
+
+# Create user account (run as root — no default user exists yet)
+Write-Host "$Tag Creating user '$WinUser'..."
+wsl --distribution $InstanceName --user root -- adduser --disabled-password --gecos '' $WinUser
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "$Tag Failed to create user '$WinUser'."
+    exit 1
+}
+
+# Add user to the sudo group
+Write-Host "$Tag Adding '$WinUser' to sudo group..."
+wsl --distribution $InstanceName --user root -- usermod -aG sudo $WinUser
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "$Tag Failed to add '$WinUser' to sudo group."
+    exit 1
+}
+
+# Write /etc/wsl.conf so the new user is the default login
+Write-Host "$Tag Setting default user in /etc/wsl.conf..."
+wsl --distribution $InstanceName --user root -- bash -c "printf '[user]\ndefault=$WinUser\n' > /etc/wsl.conf"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "$Tag Failed to write /etc/wsl.conf."
+    exit 1
+}
+
+# Terminate so wsl.conf takes effect on next launch
+Write-Host "$Tag Terminating instance to apply configuration..."
+wsl --terminate $InstanceName
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "$Tag Failed to terminate instance."
+    exit 1
+}
+
+Write-Host "$Tag Done. WSL instance '$InstanceName' is ready." -ForegroundColor Green
+Write-Host "$Tag Verify with: wsl --distribution $InstanceName -- whoami"


### PR DESCRIPTION
## Summary

- Adds `setup-wsl-debian13.ps1` — installs a named Debian 13 WSL instance, creates a user account matching the Windows username, adds it to the `sudo` group, and sets it as the default login user
- Adds `install-dev-apps.ps1` — idempotent winget installer for Windows Terminal, VS Code, and Google Chrome; skips already-installed packages

## Test plan

- [ ] Verify both scripts appear on the Windows 11 x64 platform page after build
- [ ] Confirm script frontmatter renders correctly (title, description, body markdown)
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)