### PR TITLE
fix: pass SCRIPTS_DIR=scripts-fixture to E2E step in release workflow

### DIFF
--- a/.changeset/fix-release-e2e.md
+++ b/.changeset/fix-release-e2e.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Fix release workflow E2E step to use fixture scripts directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Run E2E tests
         working-directory: 20_Applications/scriptor-web-test
+        env:
+          SCRIPTS_DIR: scripts-fixture
         run: bun run test:e2e
 
       - name: Configure GitHub Pages


### PR DESCRIPTION
## Summary

- The release workflow's E2E step was missing `SCRIPTS_DIR=scripts-fixture`, which CI already sets
- Without it, the E2E run falls back to the real `scripts/` directory — fixture scripts don't exist there, causing 9 test failures on every release deploy

## Root cause

`ci.yml` line: `SCRIPTS_DIR=scripts-fixture bunx turbo run test:e2e`
`release.yml` line: `bun run test:e2e` ← missing env var

## Test plan

- [ ] Release workflow E2E step passes with the fixture env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)