### PR TITLE
fix: run E2E against fixture build before production build in release workflow

### DIFF
--- a/.changeset/fix-release-e2e-build-order.md
+++ b/.changeset/fix-release-e2e-build-order.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Fix release workflow to run E2E against a fixture build before building for deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,21 +82,18 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build static site
-        working-directory: 20_Applications/scriptor-web
-        env:
-          NEXT_PUBLIC_VERSION: ${{ needs.changesets.outputs.version }}
-        run: bun run build
-
       - name: Install Playwright browsers
         working-directory: 20_Applications/scriptor-web-test
         run: bunx playwright install --with-deps chromium
 
-      - name: Run E2E tests
-        working-directory: 20_Applications/scriptor-web-test
+      - name: Run E2E tests (fixture build)
+        run: SCRIPTS_DIR=scripts-fixture bunx turbo run test:e2e
+
+      - name: Build static site for deploy (real scripts)
+        working-directory: 20_Applications/scriptor-web
         env:
-          SCRIPTS_DIR: scripts-fixture
-        run: bun run test:e2e
+          NEXT_PUBLIC_VERSION: ${{ needs.changesets.outputs.version }}
+        run: bun run build
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

The root cause of the release E2E failures: the workflow was building the site with
real scripts, then running Playwright tests that expect fixture scripts (`Fixture Setup
Package Manager`, etc.).

## What changed

Reordered the release `web-release` job steps:
1. Install Playwright browsers
2. **Run E2E via turbo** with `SCRIPTS_DIR=scripts-fixture` — this rebuilds the site
   with fixture scripts (identical to how CI works) and runs all Playwright tests
3. **Build for deploy** with real `scripts/` and `NEXT_PUBLIC_VERSION` — overwrites
   the fixture `out/` with the production build before upload

## Why CI passed but release failed

`ci.yml` runs `SCRIPTS_DIR=scripts-fixture bunx turbo run test:e2e`, so turbo builds
with fixtures. The release workflow was calling `bun run test:e2e` directly from the
test workspace, which only runs Playwright against the already-built `out/` — no
rebuild, so it hit real scripts that don't have the fixture titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)