### PR TITLE
fix: split WSL setup into two scripts and fix Debian 13 user creation

### DIFF
--- a/.changeset/fix-wsl-scripts.md
+++ b/.changeset/fix-wsl-scripts.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Split WSL setup into two scripts and fix Debian 13 user creation

--- a/.claude/skills/send-it/SKILL.md
+++ b/.claude/skills/send-it/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: send-it
+description: >
+  Ships code end-to-end: stage, commit, push, open a PR, watch CI, and fix
+  failures in a loop until all checks pass — then stops. With "all the way",
+  "to production", "and deploy", or "and release" also merges the PR, handles
+  the Changesets version PR, and watches the GitHub Pages deployment through to
+  completion.
+
+  Use this skill whenever the user has code ready to ship and says things like
+  "send it", "ship this", "push and PR", "check this in", "commit and create a
+  PR", "get this merged", or any phrase meaning "drive this code to a green PR".
+  Also use it when they say "send it all the way", "ship to production", or
+  "deploy this" to go the full distance to a live site.
+---
+
+# Send It
+
+Drives code from "working on my machine" to a green PR — or all the way to a
+live deployment.
+
+---
+
+## First: assess the current state
+
+Before doing anything, quickly orient:
+
+- What files have changed? (`git status`, `git diff --stat`)
+- What branch are we on? Are we already on a feature branch, or on `main`?
+- Is there already an open PR for this branch?
+- Is CI already running, or have checks already passed?
+
+Jump to the right step. Don't re-do work that's already done.
+
+---
+
+## Mode: "Send it" (default)
+
+Stop after CI goes green. Do **not** merge or deploy unless explicitly asked.
+
+### Step 1 — Pre-flight checks
+
+Run the full pre-commit suite and fix any issues before touching git:
+
+```bash
+bun run lint
+bun run format
+bun run typecheck
+bun run test:unit
+```
+
+Fix failures as you find them. After `bun run format` rewrites files, re-stage
+those files. Do not commit if any of these still fail.
+
+### Step 2 — Branch
+
+If already on a descriptive feature branch, stay. If on `main`, create one:
+
+```bash
+git checkout -b <verb>/<short-description>   # e.g. feat/add-curl-script
+```
+
+Derive the name from what the code actually does, not from the conversation.
+
+### Step 3 — Commit
+
+Stage changed files by name — not `git add .`. Avoid accidentally including
+`.env`, lock-file noise, or unrelated files.
+
+Write a commit message that explains **why** the change was made, not just what
+changed. Check `git log --oneline` to match the repo's conventions. Follow the
+project's co-author footer:
+
+```
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### Step 4 — Push and open a PR
+
+```bash
+git push -u origin <branch>
+gh pr create --title "..." --body "..."
+```
+
+PR body should include:
+- A short summary of what changed and why
+- A test plan checklist if there are meaningful things to verify
+- The Claude Code footer: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+Record the PR number.
+
+### Step 5 — CI watch-and-fix loop
+
+```bash
+gh pr checks <number> --watch
+```
+
+**All checks pass** → continue to Step 6.
+
+**Any check fails** → diagnose, fix, re-push, and watch again:
+
+```bash
+gh run view <run-id> --log-failed 2>&1 | tail -80
+```
+
+Common failure patterns in this repo:
+
+| Failure | Fix |
+|---|---|
+| Biome lint error | `bun run lint`, fix the flagged lines |
+| Biome format | `bun run format`, re-stage the reformatted files |
+| TypeScript error | fix the type error, re-run `bun run typecheck` |
+| Unit test failure | fix the test or the code, re-run `bun run test:unit` |
+| E2E test failure | tests run against `scripts-fixture/`, not `scripts/`; check that `SCRIPTS_DIR=scripts-fixture` is set in the failing step and that the fixture scripts still match what the tests expect |
+| Build failure | fix the error, run `bun run build` locally to confirm |
+
+After fixing:
+
+```bash
+git add <changed files>
+git commit -m "fix: <what was broken and why>"
+git push
+gh pr checks <number> --watch
+```
+
+Repeat until green. If the same failure appears after two fix attempts, stop
+and explain what you tried and what's still broken — don't keep guessing.
+
+### Step 6 — Return to main
+
+Once CI is green, switch back to `main` and pull the latest:
+
+```bash
+git checkout main
+git pull
+```
+
+Report the PR URL. The PR is open and waiting for a human to review.
+
+---
+
+## Mode: "All the way"
+
+Triggered by: "all the way", "to production", "and deploy", "and release",
+"and merge it". Complete all steps above first, then continue below.
+
+### Step 6 — Ensure a changeset exists
+
+Before merging, confirm `.changeset/` has an unconsumed changeset for
+`@scriptor/scriptor-web`. If not, create one:
+
+```markdown
+# .changeset/<short-name>.md
+---
+"@scriptor/scriptor-web": patch   # patch for fixes/scripts; minor for features
+---
+
+One-line description of what changed
+```
+
+Commit and push it, wait for CI to re-pass, then merge:
+
+```bash
+gh pr merge <number> --squash --delete-branch
+```
+
+### Step 7 — Handle the Changesets version PR
+
+The merge to `main` triggers the Release workflow. Watch it, then find and
+merge the auto-created version PR:
+
+```bash
+gh run list --branch main --limit 3 --json status,name,databaseId
+gh run watch <release-run-id>
+# once Changesets job completes:
+gh pr list --search "chore: version packages" --json number,url
+gh pr merge <version-pr-number> --squash --delete-branch
+```
+
+### Step 8 — Watch the deployment
+
+Merging the version PR triggers the final Release run (Changesets + Deploy):
+
+```bash
+gh run list --branch main --limit 3 --json status,name,databaseId
+gh run watch <deploy-run-id>
+gh run view <deploy-run-id> --json status,conclusion,jobs \
+  --jq '{status,conclusion,jobs:[.jobs[]|{name,conclusion,status}]}'
+```
+
+If the deployment fails, read `gh run view <id> --log-failed`, fix the issue,
+and run a new PR → merge → version PR → deploy cycle.
+
+### Step 9 — Return to main
+
+Once the deployment is confirmed live, switch back to `main` and pull the
+latest (which now includes the version bump commit):
+
+```bash
+git checkout main
+git pull
+```
+
+Report the final deployment URL and confirm you are on `main`.
+
+---
+
+## Things to avoid
+
+- Never `git add .` — always stage files by name
+- Never force-push to `main`
+- Never skip CI or use `--no-verify`
+- Never merge a PR without confirming CI is green first
+- Never proceed to "all the way" steps if the user only said "send it"
+- Don't self-approve PRs (GitHub will reject it); just merge directly when CI is green

--- a/scripts/windows/windows-11-x64/setup-wsl-debian13.ps1
+++ b/scripts/windows/windows-11-x64/setup-wsl-debian13.ps1
@@ -17,49 +17,54 @@ you like (e.g. `Debian13Dev`, `work`, `personal`).
 3. Installs Debian from the Microsoft Store via `wsl --install` without launching
    the interactive first-run setup.
 4. Creates a user account inside the distro matching the current Windows username.
-5. Adds the user to the `sudo` group.
-6. Writes `/etc/wsl.conf` to set the new user as the default login.
-7. Terminates the instance so the configuration takes effect on next launch.
+5. Prompts you to set a UNIX password for that account (used by `sudo`).
+6. Adds the user to the `sudo` group.
+7. Writes `/etc/wsl.conf` to set the new user as the default login.
+8. Terminates the instance so the configuration takes effect on next launch.
 
 ## Requirements
 
-- Windows 11 with WSL 2 support enabled.
-- `wsl.exe` installed. If not present, run: `wsl --install --no-distribution`
-- Must be run as Administrator.
+- Windows 11 with WSL 2 installed. If WSL is not set up yet, run the
+  **Set Up WSL** script first.
 #>
 
-#Requires -RunAsAdministrator
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-
-$InstanceName = ''
-while (-not $InstanceName.Trim()) {
-    $InstanceName = (Read-Host 'Enter a name for the WSL instance (e.g. Debian13Dev)').Trim()
-}
 
 $WinUser = $env:USERNAME
 $Tag = '[setup-wsl-debian13]'
 
+# Verify WSL is installed before prompting for anything
+if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+    Write-Error "$Tag wsl.exe not found. Run the 'Set Up WSL' script first."
+    exit 1
+}
+
+# Prompt for instance name, re-prompting if the name is already in use
+# wsl --list --quiet outputs UTF-16LE; normalize before comparing
+$InstanceName = ''
+while ($true) {
+    while (-not $InstanceName.Trim()) {
+        $InstanceName = (Read-Host 'Enter a name for the WSL instance (e.g. Debian13Dev)').Trim()
+    }
+
+    $ExistingInstances = (wsl --list --quiet 2>$null) |
+        ForEach-Object { $_.Trim("`0").Trim() } |
+        Where-Object { $_ -ne '' }
+
+    if ($ExistingInstances -contains $InstanceName) {
+        Write-Host "$Tag Instance '$InstanceName' already exists." -ForegroundColor Yellow
+        Write-Host "$Tag To remove it, run:  wsl --unregister $InstanceName"
+        Write-Host "$Tag Enter a different name to continue."
+        $InstanceName = ''
+    } else {
+        break
+    }
+}
+
 Write-Host "$Tag Starting..."
 Write-Host "$Tag Instance name: $InstanceName"
 Write-Host "$Tag Windows user:  $WinUser"
-
-# Verify WSL is installed
-if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
-    Write-Error "$Tag wsl.exe not found. Install WSL first:`n  wsl --install --no-distribution"
-    exit 1
-}
-
-# Check the instance does not already exist
-# wsl --list --quiet outputs UTF-16LE; normalize before comparing
-$ExistingInstances = (wsl --list --quiet 2>$null) |
-    ForEach-Object { $_.Trim("`0").Trim() } |
-    Where-Object { $_ -ne '' }
-
-if ($ExistingInstances -contains $InstanceName) {
-    Write-Error "$Tag WSL instance '$InstanceName' already exists. Remove it first:`n  wsl --unregister $InstanceName"
-    exit 1
-}
 
 # Install Debian without triggering the interactive first-run wizard
 Write-Host "$Tag Installing Debian WSL instance '$InstanceName'..."
@@ -70,10 +75,20 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Create user account (run as root — no default user exists yet)
+# useradd is used instead of adduser: Debian 13 ships adduser 4.0 which dropped
+# the --gecos flag, and PowerShell drops empty-string args when passing to WSL.
 Write-Host "$Tag Creating user '$WinUser'..."
-wsl --distribution $InstanceName --user root -- adduser --disabled-password --gecos '' $WinUser
+wsl --distribution $InstanceName --user root -- useradd --create-home --shell /bin/bash $WinUser
 if ($LASTEXITCODE -ne 0) {
     Write-Error "$Tag Failed to create user '$WinUser'."
+    exit 1
+}
+
+# Set the user's UNIX password (required for sudo)
+Write-Host "$Tag Set a password for '$WinUser' (this will be used for sudo inside WSL):"
+wsl --distribution $InstanceName --user root -- passwd $WinUser
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "$Tag Failed to set password for '$WinUser'."
     exit 1
 }
 

--- a/scripts/windows/windows-11-x64/setup-wsl.ps1
+++ b/scripts/windows/windows-11-x64/setup-wsl.ps1
@@ -1,0 +1,61 @@
+<#
+---
+platform: windows-11-x64
+title: Set Up WSL
+description: Enables the WSL 2 feature and installs the WSL kernel on Windows 11.
+---
+Enables the Windows Subsystem for Linux feature and installs the WSL 2 kernel.
+Run this once on a fresh Windows 11 system before installing any WSL distributions.
+
+Once complete, run **Setup WSL Debian 13** to install and configure a Debian 13
+instance.
+
+## What it does
+
+1. Checks whether WSL is already installed and working.
+2. If not, runs `wsl --install --no-distribution` to enable the required Windows
+   features and install the WSL 2 kernel.
+3. Advises whether a system restart is required to complete setup.
+
+## Requirements
+
+- Windows 11 with virtualization enabled in BIOS/UEFI.
+- Must be run as Administrator.
+#>
+
+#Requires -RunAsAdministrator
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Tag = '[setup-wsl]'
+
+Write-Host "$Tag Checking WSL status..."
+
+# Check if WSL is already installed and working
+$WslCmd = Get-Command wsl.exe -ErrorAction SilentlyContinue
+if ($WslCmd) {
+    $null = wsl --version 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "$Tag WSL is already installed and ready." -ForegroundColor Green
+        Write-Host "$Tag Run the 'Setup WSL Debian 13' script to install a distribution."
+        exit 0
+    }
+}
+
+Write-Host "$Tag Installing WSL (no default distribution)..."
+wsl --install --no-distribution
+switch ($LASTEXITCODE) {
+    0 {
+        Write-Host "$Tag WSL installed successfully." -ForegroundColor Green
+        Write-Host "$Tag Run the 'Setup WSL Debian 13' script to install a distribution."
+    }
+    3010 {
+        # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED (standard Windows installer exit code)
+        Write-Host "$Tag WSL installed — a system restart is required to complete setup." -ForegroundColor Yellow
+        Write-Host "$Tag After restarting, run the 'Setup WSL Debian 13' script."
+    }
+    default {
+        Write-Error "$Tag WSL installation failed (exit code $LASTEXITCODE)."
+        exit 1
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts WSL feature enablement into a new **Set Up WSL** script (`setup-wsl.ps1`), giving fresh-machine users a clear first step before installing a distro
- Updates `setup-wsl-debian13.ps1` to use `useradd` instead of `adduser` (Debian 13's adduser 4.0 dropped `--gecos`, breaking user creation)
- Adds a `passwd` step so the UNIX password is set interactively during setup (required for `sudo`)
- Removes the `#Requires -RunAsAdministrator` constraint from the Debian script (WSL operations don't need it)
- Re-prompts gracefully when the chosen instance name is already in use, instead of erroring out
- Ships the `send-it` Claude Code skill into the repo under `.claude/skills/send-it/`

## Test plan

- [ ] Run `setup-wsl.ps1` on a Windows 11 VM — verify it installs WSL or reports it's already present
- [ ] Run `setup-wsl-debian13.ps1` after WSL is set up — verify Debian installs, user is created, password prompt appears, and the instance logs in as the Windows user on next launch
- [ ] Verify the Scriptor web site still lists both Windows scripts on the windows-11-x64 platform page

🤖 Generated with [Claude Code](https://claude.com/claude-code)