### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   changesets:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to the release workflow so it can be manually re-triggered without a code push
- This also serves as the trigger to deploy the epic 004 changes — the `v0.3.0` tag was deleted (it pointed to an old ancestor commit) so this merge will allow the Release workflow to create a fresh `v0.3.0` tag and deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)