### PR TITLE
fix: standardize sudo handling and curl in debian-13-x64 scripts

### DIFF
--- a/.changeset/debian-sudo-curl-standardization.md
+++ b/.changeset/debian-sudo-curl-standardization.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Standardize sudo handling and curl auto-install in debian-13-x64 scripts

--- a/scripts/linux/debian-13-x64/configure-oh-my-bash.sh
+++ b/scripts/linux/debian-13-x64/configure-oh-my-bash.sh
@@ -22,6 +22,12 @@
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
+# Cache sudo credentials upfront so we don't prompt mid-script
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
+
 # ── Dependencies ──────────────────────────────────────────────────────────────
 
 packages_to_install=()

--- a/scripts/linux/debian-13-x64/configure-ssh-server.sh
+++ b/scripts/linux/debian-13-x64/configure-ssh-server.sh
@@ -22,7 +22,7 @@
 #
 # ## Requirements
 #
-# - Run as root or with `sudo`.
+# - Regular user with `sudo` access
 # - Internet access to reach `deb.debian.org` (package install) and `api.github.com`
 #   (key import).
 #
@@ -45,22 +45,19 @@ set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
 # ---------------------------------------------------------------------------
-# Must run as root
+# Sudo — cache credentials upfront so we don't prompt mid-script
 # ---------------------------------------------------------------------------
-if [[ "$(/usr/bin/id -u)" -ne 0 ]]; then
-	echo "Error: run as root or with sudo." >&2
-	exit 1
-fi
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
 
 # ---------------------------------------------------------------------------
 # Determine the user whose authorized_keys will be populated
 # ---------------------------------------------------------------------------
-# Use the user who invoked sudo; fall back to an interactive prompt.
-if [[ -n "${SUDO_USER:-}" ]]; then
-	TARGET_USER="$SUDO_USER"
-else
-	read -rp "Local username to import SSH keys for (leave blank to skip key import): " TARGET_USER
-fi
+TARGET_USER="${USER}"
+read -rp "Local username to import SSH keys for [${TARGET_USER}] (leave blank to skip key import): " input
+TARGET_USER="${input:-$TARGET_USER}"
 
 if [[ -n "$TARGET_USER" ]]; then
 	read -rp "GitHub username to import keys from [${TARGET_USER}]: " GH_USER
@@ -81,8 +78,8 @@ if pkg_installed openssh-server && pkg_installed ssh-import-id; then
 	echo "==> openssh-server and ssh-import-id already installed, skipping."
 else
 	echo "==> Installing openssh-server and ssh-import-id..."
-	apt-get update
-	apt-get install -y openssh-server ssh-import-id
+	sudo apt-get update
+	sudo apt-get install -y openssh-server ssh-import-id
 fi
 
 # ---------------------------------------------------------------------------
@@ -112,7 +109,7 @@ fi
 HARDENING_CONF="/etc/ssh/sshd_config.d/99-hardening.conf"
 
 echo "==> Writing hardened SSH configuration to ${HARDENING_CONF}..."
-cat > "$HARDENING_CONF" <<'EOF'
+sudo tee "$HARDENING_CONF" > /dev/null <<'EOF'
 # SSH server hardening
 # Sources:
 #   https://infosec.mozilla.org/guidelines/openssh
@@ -149,11 +146,11 @@ EOF
 # Step 4: Validate config, then reload sshd
 # ---------------------------------------------------------------------------
 echo "==> Validating SSH configuration..."
-sshd -t
+sudo sshd -t
 
 echo "==> Reloading SSH service..."
-systemctl reload ssh
+sudo systemctl reload ssh
 
 echo ""
 echo "==> Done. Active security settings:"
-sshd -T | grep -E "^(kexalgorithms|ciphers|macs|authenticationmethods|permitrootlogin|loglevel)" | sort
+sudo sshd -T | grep -E "^(kexalgorithms|ciphers|macs|authenticationmethods|permitrootlogin|loglevel)" | sort

--- a/scripts/linux/debian-13-x64/install-azure-cli.sh
+++ b/scripts/linux/debian-13-x64/install-azure-cli.sh
@@ -11,23 +11,31 @@
 #
 # ## What it does
 #
+# - Installs `curl` if not present
 # - Installs `az` via the official Microsoft Debian install script (requires sudo)
 # - Installs `azd` via the official Microsoft install script
 # - Skips each tool if it is already installed
 #
 # ## Requirements
 #
-# - `curl` must be installed (`sudo apt-get install -y curl`)
-# - `sudo` access for installing `az`
+# - Regular user with `sudo` access
 
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-check_prerequisites() {
-	if ! command -v curl &>/dev/null; then
-		echo "Error: curl is required but not installed. Run: sudo apt-get install -y curl" >&2
-		exit 1
+# Cache sudo credentials upfront so we don't prompt mid-script
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
+
+ensure_curl() {
+	if command -v curl &>/dev/null; then
+		return
 	fi
+	echo "Installing curl..."
+	sudo apt-get update -y
+	sudo apt-get install -y curl
 }
 
 install_az() {
@@ -48,7 +56,7 @@ install_azd() {
 	curl -fsSL https://aka.ms/install-azd.sh | bash
 }
 
-check_prerequisites
+ensure_curl
 install_az
 install_azd
 

--- a/scripts/linux/debian-13-x64/install-bun.sh
+++ b/scripts/linux/debian-13-x64/install-bun.sh
@@ -11,33 +11,34 @@
 #
 # ## What it does
 #
-# - Installs `unzip` if not already present (required by the Bun installer)
+# - Installs `curl` and `unzip` if not already present
 # - Downloads and runs the official Bun installer via curl
 # - Installs Bun to `~/.bun/bin/` and adds it to `PATH` in `~/.bashrc`
 # - Skips installation if Bun is already present
 #
 # ## Requirements
 #
-# - `curl` must be installed (`sudo apt-get install -y curl`)
-# - `sudo` access to install `unzip` if missing
+# - Regular user with `sudo` access
 # - Linux kernel 5.6 or higher recommended (`uname -r` to check)
 
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-check_prerequisites() {
-	if ! command -v curl &>/dev/null; then
-		echo "Error: curl is required but not installed. Run: sudo apt-get install -y curl" >&2
-		exit 1
-	fi
-}
+# Cache sudo credentials upfront so we don't prompt mid-script
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
 
-ensure_unzip() {
-	if command -v unzip &>/dev/null; then
-		return
+ensure_deps() {
+	local pkgs=()
+	command -v curl  &>/dev/null || pkgs+=(curl)
+	command -v unzip &>/dev/null || pkgs+=(unzip)
+	if [[ ${#pkgs[@]} -gt 0 ]]; then
+		echo "Installing missing packages: ${pkgs[*]}..."
+		sudo apt-get update -y
+		sudo apt-get install -y "${pkgs[@]}"
 	fi
-	echo "Installing unzip (required by the Bun installer)..."
-	sudo apt-get install -y unzip
 }
 
 install_bun() {
@@ -49,8 +50,7 @@ install_bun() {
 	curl -fsSL https://bun.com/install | bash
 }
 
-check_prerequisites
-ensure_unzip
+ensure_deps
 install_bun
 
 echo "Bun installed successfully."

--- a/scripts/linux/debian-13-x64/install-custom-certificate.sh
+++ b/scripts/linux/debian-13-x64/install-custom-certificate.sh
@@ -27,7 +27,12 @@
 set -euo pipefail
 
 TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
+SUDO_PID=""
+cleanup() {
+	[[ -n "$SUDO_PID" ]] && kill "$SUDO_PID" 2>/dev/null
+	rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
 trap 'echo "Error on line $LINENO" >&2' ERR
 
 check_prerequisites() {
@@ -150,6 +155,12 @@ install_cert() {
 
 check_prerequisites
 ensure_ca_certificates
+
+# Cache sudo credentials before the interactive certificate selection so the
+# install step doesn't prompt mid-flow
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
 
 host=$(prompt_host)
 fetch_chain "$host"

--- a/scripts/linux/debian-13-x64/install-dotnet.sh
+++ b/scripts/linux/debian-13-x64/install-dotnet.sh
@@ -11,33 +11,33 @@
 #
 # ## What it does
 #
-# - Installs `libicu-dev` if not present (required by .NET on Linux)
+# - Installs `curl` and `libicu-dev` if not present
 # - Downloads and runs the official Microsoft dotnet-install.sh for the 10.0 channel
 # - Configures `DOTNET_ROOT` and `PATH` in `~/.bashrc` if not already set
 # - Skips each step if already done
 #
 # ## Requirements
 #
-# - `curl` must be installed (`sudo apt-get install -y curl`)
-# - `sudo` access to install `libicu-dev`
+# - Regular user with `sudo` access
 
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-check_prerequisites() {
-	if ! command -v curl &>/dev/null; then
-		echo "Error: curl is required but not installed. Run: sudo apt-get install -y curl" >&2
-		exit 1
-	fi
-}
+# Cache sudo credentials upfront so we don't prompt mid-script
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
 
-ensure_libicu() {
-	if dpkg-query -W libicu-dev &>/dev/null; then
-		echo "libicu-dev is already installed, skipping"
-		return
+ensure_deps() {
+	local pkgs=()
+	command -v curl &>/dev/null || pkgs+=(curl)
+	dpkg-query -W libicu-dev &>/dev/null || pkgs+=(libicu-dev)
+	if [[ ${#pkgs[@]} -gt 0 ]]; then
+		echo "Installing missing packages: ${pkgs[*]}..."
+		sudo apt-get update -y
+		sudo apt-get install -y "${pkgs[@]}"
 	fi
-	echo "Installing libicu-dev..."
-	sudo apt-get install -y libicu-dev
 }
 
 dotnet_10_installed() {
@@ -72,8 +72,7 @@ export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 EOF
 }
 
-check_prerequisites
-ensure_libicu
+ensure_deps
 install_dotnet
 configure_path
 

--- a/scripts/linux/debian-13-x64/install-github-cli.sh
+++ b/scripts/linux/debian-13-x64/install-github-cli.sh
@@ -31,6 +31,12 @@ if command -v gh &>/dev/null; then
 	exit 0
 fi
 
+# Cache sudo credentials upfront so we don't prompt mid-script
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
+
 # ── Prerequisites ─────────────────────────────────────────────────────────────
 
 packages_to_install=()

--- a/scripts/linux/debian-13-x64/install-go.sh
+++ b/scripts/linux/debian-13-x64/install-go.sh
@@ -2,30 +2,24 @@
 # ---
 # platform: debian-13-x64
 # title: Install Go
-# description: Installs the latest stable Go toolchain from go.dev/dl into /usr/local/go.
+# description: Installs Go 1.26.2 from go.dev/dl into /usr/local/go.
 # group: debian-13-dev-box
 # group_order: 4
 # ---
-# Installs Go using the official tarball from [go.dev/dl](https://go.dev/dl/),
+# Installs Go 1.26.2 using the official tarball from [go.dev/dl](https://go.dev/dl/),
 # verifying the download against the SHA256 checksum published by the Go team.
-#
-# Debian's `golang` package tends to lag several minor versions behind upstream.
-# The tarball approach guarantees the current stable release.
 #
 # ## What it does
 #
-# 1. Queries `https://go.dev/dl/?mode=json` for the latest stable version and
-#    its SHA256 checksum.
-# 2. Skips installation if that version is already present in `/usr/local/go`.
-# 3. Downloads and verifies the tarball, then extracts it to `/usr/local/`.
+# 1. Installs `curl` if not present.
+# 2. Skips installation if Go 1.26.2 is already present in `/usr/local/go`.
+# 3. Downloads the tarball and its SHA256, verifies, then extracts to `/usr/local/`.
 # 4. Writes `/etc/profile.d/go.sh` so `/usr/local/go/bin` is on `PATH` for all
 #    users after the next login.
 #
 # ## Requirements
 #
-# - Run as root or with `sudo`.
-# - `curl` must be installed (`sudo apt-get install -y curl`).
-# - `python3` must be installed (present by default on Debian 13).
+# - Regular user with `sudo` access
 #
 # ## Verifying success
 #
@@ -44,84 +38,74 @@
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-# ---------------------------------------------------------------------------
-# Must run as root
-# ---------------------------------------------------------------------------
-if [[ "$(/usr/bin/id -u)" -ne 0 ]]; then
-	echo "Error: run as root or with sudo." >&2
-	exit 1
-fi
-
-if ! command -v curl &>/dev/null; then
-	echo "Error: curl is required. Run: sudo apt-get install -y curl" >&2
-	exit 1
-fi
-
+GO_VERSION="go1.26.2"
 ARCH="amd64"  # platform: debian-13-x64
 INSTALL_DIR="/usr/local"
 PROFILE_SCRIPT="/etc/profile.d/go.sh"
 
 # ---------------------------------------------------------------------------
-# Step 1: Resolve latest stable version and SHA256 from go.dev
+# Sudo — cache credentials upfront, clean up keepalive on exit
 # ---------------------------------------------------------------------------
-echo "==> Querying latest stable Go release from go.dev..."
-RELEASE_JSON=$(curl -fsSL 'https://go.dev/dl/?mode=json')
-
-read -r LATEST_VERSION SHA256 < <(
-	python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for f in data[0]['files']:
-    if f['os'] == 'linux' and f['arch'] == 'amd64' and f['kind'] == 'archive':
-        print(data[0]['version'], f['sha256'])
-        break
-" <<< "$RELEASE_JSON"
-)
-
-echo "==> Latest stable: ${LATEST_VERSION}"
+sudo -v
+TMP_DIR=$(mktemp -d)
+SUDO_PID=""
+cleanup() {
+	[[ -n "$SUDO_PID" ]] && kill "$SUDO_PID" 2>/dev/null
+	rm -rf "${TMP_DIR:?}"
+}
+trap cleanup EXIT
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
 
 # ---------------------------------------------------------------------------
-# Step 2: Skip if already at this version
+# Ensure curl
 # ---------------------------------------------------------------------------
-if [[ -x "${INSTALL_DIR}/go/bin/go" ]]; then
-	INSTALLED=$("${INSTALL_DIR}/go/bin/go" version | awk '{print $3}')
-	if [[ "$INSTALLED" == "$LATEST_VERSION" ]]; then
-		echo "==> ${LATEST_VERSION} is already installed, nothing to do."
-		exit 0
-	fi
-	echo "==> Upgrading ${INSTALLED} → ${LATEST_VERSION}..."
-else
-	echo "==> Installing ${LATEST_VERSION}..."
+if ! command -v curl &>/dev/null; then
+	echo "==> Installing curl..."
+	sudo apt-get update -y
+	sudo apt-get install -y curl
 fi
 
 # ---------------------------------------------------------------------------
-# Step 3: Download and verify tarball
+# Step 1: Skip if already at this version
 # ---------------------------------------------------------------------------
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "${TMP_DIR:?}"' EXIT
+if [[ -x "${INSTALL_DIR}/go/bin/go" ]]; then
+	INSTALLED=$("${INSTALL_DIR}/go/bin/go" version | awk '{print $3}')
+	if [[ "$INSTALLED" == "$GO_VERSION" ]]; then
+		echo "==> ${GO_VERSION} is already installed, nothing to do."
+		exit 0
+	fi
+	echo "==> Upgrading ${INSTALLED} → ${GO_VERSION}..."
+else
+	echo "==> Installing ${GO_VERSION}..."
+fi
 
-TARBALL="${LATEST_VERSION}.linux-${ARCH}.tar.gz"
+# ---------------------------------------------------------------------------
+# Step 2: Download and verify tarball
+# ---------------------------------------------------------------------------
+TARBALL="${GO_VERSION}.linux-${ARCH}.tar.gz"
 echo "==> Downloading ${TARBALL}..."
 curl -fL "https://go.dev/dl/${TARBALL}" -o "${TMP_DIR}/${TARBALL}"
+curl -fL "https://go.dev/dl/${TARBALL}.sha256" -o "${TMP_DIR}/${TARBALL}.sha256"
 
 echo "==> Verifying SHA256..."
-echo "${SHA256}  ${TMP_DIR}/${TARBALL}" | sha256sum -c -
+echo "$(cat "${TMP_DIR}/${TARBALL}.sha256")  ${TMP_DIR}/${TARBALL}" | sha256sum -c -
 
 # ---------------------------------------------------------------------------
-# Step 4: Extract to /usr/local/
+# Step 3: Extract to /usr/local/
 # ---------------------------------------------------------------------------
 echo "==> Extracting to ${INSTALL_DIR}..."
-rm -rf "${INSTALL_DIR}/go"
-tar -C "${INSTALL_DIR}" -xzf "${TMP_DIR}/${TARBALL}"
+sudo rm -rf "${INSTALL_DIR}/go"
+sudo tar -C "${INSTALL_DIR}" -xzf "${TMP_DIR}/${TARBALL}"
 
 # ---------------------------------------------------------------------------
-# Step 5: Add /usr/local/go/bin to PATH for all users
+# Step 4: Add /usr/local/go/bin to PATH for all users
 # ---------------------------------------------------------------------------
-cat > "$PROFILE_SCRIPT" <<'EOF'
+sudo tee "$PROFILE_SCRIPT" > /dev/null <<'EOF'
 # Go toolchain — managed by Scriptor
 export PATH="$PATH:/usr/local/go/bin"
 EOF
-chmod 644 "$PROFILE_SCRIPT"
+sudo chmod 644 "$PROFILE_SCRIPT"
 
 echo ""
 echo "==> Installed: $("${INSTALL_DIR}/go/bin/go" version)"

--- a/scripts/linux/debian-13-x64/install-minikube.sh
+++ b/scripts/linux/debian-13-x64/install-minikube.sh
@@ -11,7 +11,7 @@
 #
 # ## What it does
 #
-# 1. Installs `conntrack` (required by minikube on Linux).
+# 1. Installs `curl` and `conntrack` if not present (conntrack required by minikube on Linux).
 # 2. Resolves the latest stable kubectl version from `dl.k8s.io/release/stable.txt`,
 #    downloads the binary and its SHA256, and installs it if not already current.
 # 3. Resolves the latest minikube release from the GitHub API, downloads the
@@ -20,8 +20,7 @@
 #
 # ## Requirements
 #
-# - Run as root or with `sudo`.
-# - `curl` must be installed (`sudo apt-get install -y curl`).
+# - Regular user with `sudo` access
 # - **Docker** must be installed and the user who will run `minikube start`
 #   must be in the `docker` group. Docker does not need to be installed before
 #   running this script, but minikube will not start without it.
@@ -44,21 +43,22 @@
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-# ---------------------------------------------------------------------------
-# Must run as root
-# ---------------------------------------------------------------------------
-if [[ "$(/usr/bin/id -u)" -ne 0 ]]; then
-	echo "Error: run as root or with sudo." >&2
-	exit 1
-fi
-
-if ! command -v curl &>/dev/null; then
-	echo "Error: curl is required. Run: sudo apt-get install -y curl" >&2
-	exit 1
-fi
-
 ARCH="amd64"  # platform: debian-13-x64
 BIN_DIR="/usr/local/bin"
+
+# ---------------------------------------------------------------------------
+# Sudo — cache credentials upfront, clean up keepalive on exit
+# ---------------------------------------------------------------------------
+sudo -v
+TMP_DIR=$(mktemp -d)
+SUDO_PID=""
+cleanup() {
+	[[ -n "$SUDO_PID" ]] && kill "$SUDO_PID" 2>/dev/null
+	rm -rf "${TMP_DIR:?}"
+}
+trap cleanup EXIT
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
 
 # ---------------------------------------------------------------------------
 # Helper: check if a package is fully installed
@@ -68,24 +68,20 @@ pkg_installed() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 1: Install conntrack (required by minikube on Linux)
+# Ensure curl and conntrack
 # ---------------------------------------------------------------------------
-if pkg_installed conntrack; then
-	echo "==> conntrack already installed, skipping."
-else
-	echo "==> Installing conntrack..."
-	apt-get update
-	apt-get install -y conntrack
+pkgs_needed=()
+command -v curl &>/dev/null   || pkgs_needed+=(curl)
+pkg_installed conntrack        || pkgs_needed+=(conntrack)
+
+if [[ ${#pkgs_needed[@]} -gt 0 ]]; then
+	echo "==> Installing missing packages: ${pkgs_needed[*]}..."
+	sudo apt-get update -y
+	sudo apt-get install -y "${pkgs_needed[@]}"
 fi
 
 # ---------------------------------------------------------------------------
-# Temp dir — cleaned up on exit
-# ---------------------------------------------------------------------------
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "${TMP_DIR:?}"' EXIT
-
-# ---------------------------------------------------------------------------
-# Step 2: Install kubectl
+# Step 1: Install kubectl
 # ---------------------------------------------------------------------------
 echo "==> Resolving latest stable kubectl version..."
 KUBECTL_STABLE=$(curl -fsSL 'https://dl.k8s.io/release/stable.txt')
@@ -111,12 +107,12 @@ else
 	echo "==> Verifying kubectl SHA256..."
 	echo "$(cat "${TMP_DIR}/kubectl.sha256")  ${TMP_DIR}/kubectl" | sha256sum -c -
 
-	install -o root -g root -m 0755 "${TMP_DIR}/kubectl" "${BIN_DIR}/kubectl"
+	sudo install -o root -g root -m 0755 "${TMP_DIR}/kubectl" "${BIN_DIR}/kubectl"
 	echo "==> kubectl installed: $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
 fi
 
 # ---------------------------------------------------------------------------
-# Step 3: Install minikube
+# Step 2: Install minikube
 # ---------------------------------------------------------------------------
 echo "==> Resolving latest minikube release..."
 MINIKUBE_LATEST=$(curl -fsSL 'https://api.github.com/repos/kubernetes/minikube/releases/latest' \
@@ -141,12 +137,12 @@ else
 	echo "==> Verifying minikube SHA256..."
 	echo "$(cat "${TMP_DIR}/minikube.sha256")  ${TMP_DIR}/minikube" | sha256sum -c -
 
-	install -o root -g root -m 0755 "${TMP_DIR}/minikube" "${BIN_DIR}/minikube"
+	sudo install -o root -g root -m 0755 "${TMP_DIR}/minikube" "${BIN_DIR}/minikube"
 	echo "==> minikube installed: $(minikube version --short)"
 fi
 
 # ---------------------------------------------------------------------------
-# Step 4: Detect container runtime and print driver instructions
+# Step 3: Detect container runtime and print driver instructions
 # ---------------------------------------------------------------------------
 echo ""
 if command -v docker &>/dev/null; then

--- a/scripts/linux/debian-13-x64/install-nvidia.sh
+++ b/scripts/linux/debian-13-x64/install-nvidia.sh
@@ -12,7 +12,7 @@
 #
 # - **Secure Boot must be disabled** in BIOS/UEFI. The DKMS module is unsigned and will
 #   not load with Secure Boot enabled.
-# - Run as root or with `sudo`.
+# - Regular user with `sudo` access
 # - Internet access to reach `deb.debian.org`.
 #
 # ## What it does
@@ -41,20 +41,20 @@
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-# ---------------------------------------------------------------------------
-# Must run as root
-# ---------------------------------------------------------------------------
-if [[ "$(/usr/bin/id -u)" -ne 0 ]]; then
-	echo "Error: run as root or with sudo." >&2
-	exit 1
-fi
-
 echo "=========================================================="
 echo "  IMPORTANT: Secure Boot must be disabled in BIOS/UEFI."
 echo "  The NVIDIA DKMS module will not load if Secure Boot is"
 echo "  enabled. Verify this before continuing."
 echo "=========================================================="
 read -rp "Secure Boot is disabled — press Enter to continue..."
+
+# ---------------------------------------------------------------------------
+# Sudo — cache credentials upfront so we don't prompt mid-script
+# ---------------------------------------------------------------------------
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
 
 # ---------------------------------------------------------------------------
 # Helper: check if a package is installed
@@ -74,30 +74,30 @@ if [[ -f "$DEB822_SOURCES" ]]; then
 		echo "==> non-free already enabled in ${DEB822_SOURCES}, skipping."
 	else
 		echo "==> Enabling contrib, non-free, non-free-firmware in ${DEB822_SOURCES}..."
-		sed -i 's/^Components: main.*/Components: main contrib non-free non-free-firmware/' "$DEB822_SOURCES"
+		sudo sed -i 's/^Components: main.*/Components: main contrib non-free non-free-firmware/' "$DEB822_SOURCES"
 	fi
 elif [[ -f "$LEGACY_SOURCES" ]]; then
 	if grep -q "non-free" "$LEGACY_SOURCES"; then
 		echo "==> non-free already enabled in ${LEGACY_SOURCES}, skipping."
 	else
 		echo "==> Enabling contrib, non-free, non-free-firmware in ${LEGACY_SOURCES}..."
-		sed -i 's/trixie \+main.*/trixie main contrib non-free non-free-firmware/g' "$LEGACY_SOURCES"
-		sed -i 's/trixie-security \+main.*/trixie-security main contrib non-free non-free-firmware/g' "$LEGACY_SOURCES"
-		sed -i 's/trixie-updates \+main.*/trixie-updates main contrib non-free non-free-firmware/g' "$LEGACY_SOURCES"
+		sudo sed -i 's/trixie \+main.*/trixie main contrib non-free non-free-firmware/g' "$LEGACY_SOURCES"
+		sudo sed -i 's/trixie-security \+main.*/trixie-security main contrib non-free non-free-firmware/g' "$LEGACY_SOURCES"
+		sudo sed -i 's/trixie-updates \+main.*/trixie-updates main contrib non-free non-free-firmware/g' "$LEGACY_SOURCES"
 	fi
 else
 	echo "Error: no APT sources file found (checked ${DEB822_SOURCES} and ${LEGACY_SOURCES})." >&2
 	exit 1
 fi
 
-apt-get update
+sudo apt-get update
 
 # ---------------------------------------------------------------------------
 # Step 2: Run nvidia-detect to confirm GPU and recommended driver
 # ---------------------------------------------------------------------------
 if ! pkg_installed nvidia-detect; then
 	echo "==> Installing nvidia-detect..."
-	apt-get install -y nvidia-detect
+	sudo apt-get install -y nvidia-detect
 fi
 
 echo "==> Detecting NVIDIA GPU..."
@@ -111,7 +111,7 @@ if pkg_installed "linux-headers-${KERNEL_VERSION}"; then
 	echo "==> Kernel headers for ${KERNEL_VERSION} already installed, skipping."
 else
 	echo "==> Installing kernel headers for ${KERNEL_VERSION}..."
-	apt-get install -y "linux-headers-${KERNEL_VERSION}"
+	sudo apt-get install -y "linux-headers-${KERNEL_VERSION}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -121,7 +121,7 @@ if pkg_installed nvidia-driver; then
 	echo "==> nvidia-driver already installed, skipping."
 else
 	echo "==> Installing nvidia-driver, nvidia-kernel-dkms, firmware-misc-nonfree..."
-	apt-get install -y nvidia-driver nvidia-kernel-dkms firmware-misc-nonfree
+	sudo apt-get install -y nvidia-driver nvidia-kernel-dkms firmware-misc-nonfree
 fi
 
 # ---------------------------------------------------------------------------
@@ -131,7 +131,7 @@ if pkg_installed nvidia-cuda-toolkit; then
 	echo "==> CUDA toolkit already installed, skipping."
 else
 	echo "==> Installing CUDA development tools..."
-	apt-get install -y nvidia-cuda-dev nvidia-cuda-toolkit
+	sudo apt-get install -y nvidia-cuda-dev nvidia-cuda-toolkit
 fi
 
 # ---------------------------------------------------------------------------
@@ -140,7 +140,7 @@ fi
 if pkg_installed xserver-xorg-core; then
 	if ! pkg_installed nvidia-xconfig; then
 		echo "==> X server detected — installing nvidia-xconfig..."
-		apt-get install -y nvidia-xconfig
+		sudo apt-get install -y nvidia-xconfig
 	fi
 	echo "==> After reboot, run: nvidia-xconfig"
 fi

--- a/scripts/linux/debian-13-x64/install-podman.sh
+++ b/scripts/linux/debian-13-x64/install-podman.sh
@@ -22,9 +22,7 @@
 #
 # ## Requirements
 #
-# - Run as root or with `sudo`.
-# - The target user is detected from `$SUDO_USER`; if run directly as root,
-#   you will be prompted.
+# - Regular user with `sudo` access
 # - Kernel must support cgroup v2 (default on Debian 13).
 #
 # ## Verifying success
@@ -54,26 +52,17 @@ if grep -qi "microsoft-standard-WSL" /proc/version 2>/dev/null; then
 fi
 
 # ---------------------------------------------------------------------------
-# Must run as root
+# Sudo — cache credentials upfront so we don't prompt mid-script
 # ---------------------------------------------------------------------------
-if [[ "$(/usr/bin/id -u)" -ne 0 ]]; then
-	echo "Error: run as root or with sudo." >&2
-	exit 1
-fi
+sudo -v
+while true; do sudo -n true; sleep 55; done &
+SUDO_PID=$!
+trap 'kill "$SUDO_PID" 2>/dev/null' EXIT
 
 # ---------------------------------------------------------------------------
 # Determine the user to configure for rootless access
 # ---------------------------------------------------------------------------
-if [[ -n "${SUDO_USER:-}" ]]; then
-	TARGET_USER="$SUDO_USER"
-else
-	read -rp "Username to configure for rootless podman: " TARGET_USER
-fi
-
-if [[ -z "$TARGET_USER" ]]; then
-	echo "Error: no target user specified." >&2
-	exit 1
-fi
+TARGET_USER="${USER}"
 
 if ! id "$TARGET_USER" &>/dev/null; then
 	echo "Error: user '${TARGET_USER}' does not exist." >&2
@@ -101,8 +90,8 @@ if [[ "${#MISSING[@]}" -eq 0 ]]; then
 	echo "==> All podman packages already installed, skipping."
 else
 	echo "==> Installing: ${MISSING[*]}..."
-	apt-get update
-	apt-get install -y "${MISSING[@]}"
+	sudo apt-get update
+	sudo apt-get install -y "${MISSING[@]}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -119,14 +108,14 @@ if grep -q "^${TARGET_USER}:" "$SUBUID_FILE" 2>/dev/null; then
 	echo "==> subuid already configured for ${TARGET_USER}, skipping."
 else
 	echo "==> Adding subuid range for ${TARGET_USER}..."
-	usermod --add-subuids "$SUBID_RANGE" "$TARGET_USER"
+	sudo usermod --add-subuids "$SUBID_RANGE" "$TARGET_USER"
 fi
 
 if grep -q "^${TARGET_USER}:" "$SUBGID_FILE" 2>/dev/null; then
 	echo "==> subgid already configured for ${TARGET_USER}, skipping."
 else
 	echo "==> Adding subgid range for ${TARGET_USER}..."
-	usermod --add-subgids "$SUBID_RANGE" "$TARGET_USER"
+	sudo usermod --add-subgids "$SUBID_RANGE" "$TARGET_USER"
 fi
 
 # ---------------------------------------------------------------------------
@@ -147,15 +136,14 @@ if [[ "$IN_WSL" == "true" ]]; then
 	if grep -q "cgroup_manager" "$CONTAINERS_CONF" 2>/dev/null; then
 		echo "==> containers.conf already configured, skipping."
 	else
-		sudo -H -u "$TARGET_USER" mkdir -p "${TARGET_HOME}/.config/containers"
-		cat > "$CONTAINERS_CONF" <<'EOF'
+		mkdir -p "${TARGET_HOME}/.config/containers"
+		tee "$CONTAINERS_CONF" > /dev/null <<'EOF'
 [engine]
 # WSL2: systemd user sessions are unreliable — use cgroupfs instead
 cgroup_manager = "cgroupfs"
 # WSL2: journald is unavailable — write events to a file instead
 events_logger = "file"
 EOF
-		chown "$TARGET_USER:" "$CONTAINERS_CONF"
 		echo "==> containers.conf written to ${CONTAINERS_CONF}"
 	fi
 else
@@ -171,7 +159,7 @@ elif loginctl show-user "$TARGET_USER" 2>/dev/null | grep -q "Linger=yes"; then
 	echo "==> Systemd linger already enabled for ${TARGET_USER}, skipping."
 else
 	echo "==> Enabling systemd linger for ${TARGET_USER}..."
-	loginctl enable-linger "$TARGET_USER"
+	sudo loginctl enable-linger "$TARGET_USER"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/linux/debian-13-x64/install-uv.sh
+++ b/scripts/linux/debian-13-x64/install-uv.sh
@@ -11,22 +11,27 @@
 #
 # ## What it does
 #
+# - Installs `curl` if not present
 # - Downloads and runs the official uv installer via curl
 # - Installs uv to `~/.local/bin/uv` (no sudo required)
 # - Skips installation if uv is already present
 #
 # ## Requirements
 #
-# - `curl` must be installed (`sudo apt-get install -y curl`)
+# - Regular user with `sudo` access (only needed if `curl` is missing)
+# - Internet connection
 
 set -euo pipefail
 trap 'echo "Script failed on line $LINENO" >&2' ERR
 
-check_prerequisites() {
-	if ! command -v curl &>/dev/null; then
-		echo "Error: curl is required but not installed. Run: sudo apt-get install -y curl" >&2
-		exit 1
+ensure_curl() {
+	if command -v curl &>/dev/null; then
+		return
 	fi
+	echo "Installing curl..."
+	sudo -v
+	sudo apt-get update -y
+	sudo apt-get install -y curl
 }
 
 install_uv() {
@@ -38,7 +43,7 @@ install_uv() {
 	curl -LsSf https://astral.sh/uv/install.sh | sh
 }
 
-check_prerequisites
+ensure_curl
 install_uv
 
 echo "uv installed successfully."


### PR DESCRIPTION
## Summary

- All scripts that invoke privileged commands now validate sudo credentials upfront with `sudo -v` and keep them alive via a background keepalive loop — no more mid-script password prompts
- Scripts that previously checked for `curl` and exited with an error now auto-install it via `apt-get` if missing
- `install-go.sh`: removed Python3/JSON API dependency for version detection; Go version is now hardcoded to `1.26.2` with SHA256 fetched directly from `go.dev/dl`
- Scripts with both a temp dir and a sudo keepalive use a combined `cleanup()` EXIT handler to avoid trap clobbering

## Test plan

- [ ] Run each modified script on a fresh Debian 13 install to verify sudo is prompted once at the start and not mid-script
- [ ] Test on a system without `curl` pre-installed to confirm auto-install path works
- [ ] Verify `install-go.sh` installs Go 1.26.2 and skips correctly if already at that version
- [ ] All scripts pass `shellcheck` (verified locally — no output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)