### PR TITLE
fix: strip CRLF from go.dev SHA256 before verifying checksum

### DIFF
--- a/.changeset/fix-go-sha256-crlf.md
+++ b/.changeset/fix-go-sha256-crlf.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Fix SHA256 verification in install-go.sh failing due to CRLF line endings

--- a/scripts/linux/debian-13-x64/install-go.sh
+++ b/scripts/linux/debian-13-x64/install-go.sh
@@ -89,7 +89,8 @@ curl -fL "https://go.dev/dl/${TARBALL}" -o "${TMP_DIR}/${TARBALL}"
 curl -fL "https://go.dev/dl/${TARBALL}.sha256" -o "${TMP_DIR}/${TARBALL}.sha256"
 
 echo "==> Verifying SHA256..."
-echo "$(cat "${TMP_DIR}/${TARBALL}.sha256")  ${TMP_DIR}/${TARBALL}" | sha256sum -c -
+EXPECTED_SHA=$(tr -d '[:space:]' < "${TMP_DIR}/${TARBALL}.sha256")
+echo "${EXPECTED_SHA}  ${TMP_DIR}/${TARBALL}" | sha256sum -c -
 
 # ---------------------------------------------------------------------------
 # Step 3: Extract to /usr/local/


### PR DESCRIPTION
## Summary

- `go.dev` serves `.sha256` files with CRLF line endings
- The trailing `\r` was embedded in the hash string, causing `sha256sum -c` to report "no properly formatted checksum lines found"
- Fix: `EXPECTED_SHA=$(tr -d '[:space:]' < ...)` strips all whitespace before constructing the checksum line

## Test plan

- [ ] Run `install-go.sh` on a Debian 13 machine and confirm SHA256 verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)