### PR TITLE
fix: don't fail on openssl exit code when fetching cert chain

### DIFF
--- a/.changeset/fix-custom-cert-openssl-exit.md
+++ b/.changeset/fix-custom-cert-openssl-exit.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+Fix install-custom-certificate.sh crashing with "awk: cannot open chain.pem" behind SSL inspection proxies

--- a/scripts/linux/debian-13-x64/install-custom-certificate.sh
+++ b/scripts/linux/debian-13-x64/install-custom-certificate.sh
@@ -65,23 +65,23 @@ prompt_host() {
 fetch_chain() {
 	local host="$1"
 	echo "Fetching certificate chain from ${host}:443..."
-	if ! timeout 15 openssl s_client -connect "${host}:443" -showcerts \
-			</dev/null > "$TMP_DIR/chain.pem" 2>/dev/null; then
-		echo "Error: could not connect to ${host}:443" >&2
-		exit 1
-	fi
-	if ! grep -q 'BEGIN CERTIFICATE' "$TMP_DIR/chain.pem"; then
-		echo "Error: no certificates returned by ${host}" >&2
+	# Ignore openssl's exit code: SSL inspection proxies cause verification failures
+	# (exit 1) even when the cert chain is successfully captured in the output.
+	# The grep check below is the only success gate we need.
+	timeout 15 openssl s_client -connect "${host}:443" -showcerts \
+		</dev/null > "$TMP_DIR/chain.pem" 2>/dev/null || true
+	if ! grep -q 'BEGIN CERTIFICATE' "$TMP_DIR/chain.pem" 2>/dev/null; then
+		echo "Error: could not retrieve certificate chain from ${host}:443" >&2
 		exit 1
 	fi
 }
 
 extract_certs() {
-	awk '
+	awk -v out_dir="$TMP_DIR" '
 		/-----BEGIN CERTIFICATE-----/ { n++; f = out_dir "/cert_" n ".pem" }
 		f { print > f }
 		/-----END CERTIFICATE-----/ { close(f); f = "" }
-	' out_dir="$TMP_DIR" "$TMP_DIR/chain.pem"
+	' "$TMP_DIR/chain.pem"
 }
 
 count_certs() {


### PR DESCRIPTION
## Summary

- `openssl s_client` exits non-zero when certificate verification fails — which is exactly the situation for SSL inspection proxies like Zscaler (the entire point of this script). Our `if !` handler was treating that as "couldn't connect" and calling `exit 1`, which fired the `cleanup()` EXIT trap and deleted `TMP_DIR`. The script terminated before `extract_certs` ran, but the error surface was the confusing "awk: cannot open chain.pem" message.
- Fix: use `|| true` so openssl's exit code is ignored. The only success gate is whether PEM certificate blocks appear in the output.
- Also switched `awk` to use `-v out_dir=...` instead of positional variable assignment (cleaner and more portable).

## Test plan

- [ ] Run on a system behind an SSL inspection proxy — should now successfully display the cert chain instead of crashing
- [ ] Run on a normal system — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)