### PR TITLE
fix: redirect interactive reads to /dev/tty so curl | bash works

### DIFF
--- a/.changeset/custom-cert-tty-reads.md
+++ b/.changeset/custom-cert-tty-reads.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+fix: redirect interactive reads to /dev/tty so install-custom-certificate.sh works via curl | bash

--- a/.claude/skills/send-it/SKILL.md
+++ b/.claude/skills/send-it/SKILL.md
@@ -7,11 +7,11 @@ description: >
   the Changesets version PR, and watches the GitHub Pages deployment through to
   completion.
 
-  Use this skill whenever the user has code ready to ship and says things like
-  "send it", "ship this", "push and PR", "check this in", "commit and create a
-  PR", "get this merged", or any phrase meaning "drive this code to a green PR".
-  Also use it when they say "send it all the way", "ship to production", or
-  "deploy this" to go the full distance to a live site.
+  ONLY use this skill when the user explicitly invokes it by name ("/send-it"
+  or "send it"). Do NOT infer invocation from general phrases like "ship this",
+  "push this", "commit and PR", or similar. No push, PR creation, PR merge,
+  or release action may happen unless the user explicitly calls this skill.
+disable-model-invocation: true
 ---
 
 # Send It
@@ -213,3 +213,18 @@ Report the final deployment URL and confirm you are on `main`.
 - Never merge a PR without confirming CI is green first
 - Never proceed to "all the way" steps if the user only said "send it"
 - Don't self-approve PRs (GitHub will reject it); just merge directly when CI is green
+
+## Hard stops — explicit direction required
+
+These actions must **never** happen automatically or speculatively. Each requires
+an explicit user instruction before proceeding:
+
+- `git push` — do not push without being told to
+- `gh pr create` — do not open a PR without being told to
+- `gh pr merge` — do not merge a PR without being told to
+- Changeset creation — do not create a changeset without being told to
+- Any release or deployment step
+
+If you are operating outside this skill (e.g. in a regular conversation) and the
+user says something that sounds like "ship it" or "push this", do **not** invoke
+any of these actions. Ask for explicit confirmation or direct the user to `/send-it`.

--- a/scripts/linux/debian-13-x64/install-custom-certificate.sh
+++ b/scripts/linux/debian-13-x64/install-custom-certificate.sh
@@ -54,7 +54,7 @@ ensure_ca_certificates() {
 
 prompt_host() {
 	local url
-	read -r -p "Enter URL to inspect [www.google.com]: " url
+	read -r -p "Enter URL to inspect [www.google.com]: " url </dev/tty
 	url="${url:-www.google.com}"
 	url="${url#https://}"
 	url="${url#http://}"
@@ -113,7 +113,7 @@ get_selection() {
 	local cert_count="$1"
 	local selection
 	while true; do
-		read -r -p "Select certificate to install as trusted CA [1-${cert_count}]: " selection
+		read -r -p "Select certificate to install as trusted CA [1-${cert_count}]: " selection </dev/tty
 		if [[ "$selection" =~ ^[0-9]+$ ]] && \
 		   [[ "$selection" -ge 1 ]] && \
 		   [[ "$selection" -le "$cert_count" ]]; then
@@ -153,17 +153,6 @@ install_cert() {
 
 # --- Main ---
 
-# This script has interactive prompts and cannot run via curl | bash.
-# Stdin must be a terminal so the URL, certificate selection, and confirmation
-# prompts can be answered.
-if [[ ! -t 0 ]]; then
-	echo "Error: this script requires an interactive terminal." >&2
-	echo "Download it first, then run it:" >&2
-	echo "  curl -fsSL https://raw.githubusercontent.com/beolson/Scriptor/main/scripts/linux/debian-13-x64/install-custom-certificate.sh -o install-cert.sh" >&2
-	echo "  bash install-cert.sh" >&2
-	exit 1
-fi
-
 check_prerequisites
 ensure_ca_certificates
 
@@ -197,7 +186,7 @@ printf '\nSelected certificate:\n'
 openssl x509 -noout -subject -issuer -dates -in "$selected_cert" 2>/dev/null | sed 's/^/  /'
 
 printf '\n'
-read -r -p "Install '${cert_name}' as a trusted CA? [y/N]: " confirm
+read -r -p "Install '${cert_name}' as a trusted CA? [y/N]: " confirm </dev/tty
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
 	echo "Aborted."
 	exit 0

--- a/scripts/linux/debian-13-x64/install-custom-certificate.sh
+++ b/scripts/linux/debian-13-x64/install-custom-certificate.sh
@@ -153,6 +153,17 @@ install_cert() {
 
 # --- Main ---
 
+# This script has interactive prompts and cannot run via curl | bash.
+# Stdin must be a terminal so the URL, certificate selection, and confirmation
+# prompts can be answered.
+if [[ ! -t 0 ]]; then
+	echo "Error: this script requires an interactive terminal." >&2
+	echo "Download it first, then run it:" >&2
+	echo "  curl -fsSL https://raw.githubusercontent.com/beolson/Scriptor/main/scripts/linux/debian-13-x64/install-custom-certificate.sh -o install-cert.sh" >&2
+	echo "  bash install-cert.sh" >&2
+	exit 1
+fi
+
 check_prerequisites
 ensure_ca_certificates
 


### PR DESCRIPTION
## Summary

- Replaces the piped-stdin guard (which blocked `curl | bash` with an error) with explicit `</dev/tty` redirects on each `read` prompt
- The script can now be piped but still interactively prompts the terminal for URL, cert selection, and confirmation
- Also tightens the `send-it` skill to require explicit `/send-it` invocation — no push, PR, merge, or release without the user calling it directly

## Test plan

- [ ] `curl -fsSL <url> | bash` — prompts appear correctly in terminal
- [ ] Direct `bash install-custom-certificate.sh` — unaffected
- [ ] Confirm no regression in CI (lint, typecheck, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)