### PR TITLE
fix: fetch go SHA256 from dl.google.com, not go.dev

### DIFF
--- a/.changeset/go-sha256-dl-google.md
+++ b/.changeset/go-sha256-dl-google.md
@@ -1,0 +1,5 @@
+---
+"@scriptor/scriptor-web": patch
+---
+
+fix: fetch go SHA256 from dl.google.com instead of go.dev to avoid HTML redirect

--- a/scripts/linux/debian-13-x64/install-go.sh
+++ b/scripts/linux/debian-13-x64/install-go.sh
@@ -86,7 +86,8 @@ fi
 TARBALL="${GO_VERSION}.linux-${ARCH}.tar.gz"
 echo "==> Downloading ${TARBALL}..."
 curl -fL "https://go.dev/dl/${TARBALL}" -o "${TMP_DIR}/${TARBALL}"
-curl -fL "https://go.dev/dl/${TARBALL}.sha256" -o "${TMP_DIR}/${TARBALL}.sha256"
+# go.dev/dl/*.sha256 redirects to an HTML anchor, not a file — use dl.google.com directly
+curl -fL "https://dl.google.com/go/${TARBALL}.sha256" -o "${TMP_DIR}/${TARBALL}.sha256"
 
 echo "==> Verifying SHA256..."
 EXPECTED_SHA=$(tr -d '[:space:]' < "${TMP_DIR}/${TARBALL}.sha256")


### PR DESCRIPTION
## Summary

- `go.dev/dl/*.sha256` redirects to an HTML anchor fragment (`#go1.x.linux-amd64.tar.gz.sha256`) that `curl -L` cannot follow as a file — it lands on the HTML download page instead
- `dl.google.com/go/*.sha256` serves the raw 64-char hash directly
- Switches the SHA256 fetch URL accordingly; tarball download URL (go.dev) is unchanged since that redirect works correctly

## Test plan

- [ ] Run `install-go.sh` end-to-end and confirm SHA256 verification passes
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)